### PR TITLE
Feat: 게시글 읽기 기능 구현 #11

### DIFF
--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,27 +1,34 @@
-import { POSTS_PATH } from '@/src/lib/constants';
 import PostHeader from '../../../components/PostHeader';
 import PostBody from '../../../components/PostBody';
 import Giscus from '../../../components/Giscus';
+import {
+	getPostFromSlug,
+	getPostSlugs,
+} from '@/src/utils/supabase/clientActions';
 
-export function generateStaticParams() {
-	// const slugs = getPostSlugsFrom(POSTS_PATH);
-	// return slugs.map((slug) => ({
-	// 	slug: slug,
-	// }));
+export async function generateStaticParams() {
+	const slugs = await getPostSlugs();
+
+	return slugs?.map((item) => ({
+		slug: item.slug,
+	}));
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
-	// JSON으로 변환해서 렌더링할것
+	const post = await getPostFromSlug(params.slug);
+
+	if (!post) {
+		return <div>Post not found</div>;
+	}
 
 	return (
 		<>
-			{/* <PostHeader
-				title={title}
-				dateString={createdAt}
-				readingMinutes={readingMinutes}
-			/> */}
-			{/* 변환된 코드에 맞춰서 PostBody 컴포넌트 수정할 것 */}
-			{/* <PostBody postContent={postContent} /> */}
+			<PostHeader
+				title={post.title}
+				created_at={post.created_at}
+				reading_time={post.reading_time}
+			/>
+			<PostBody postContent={post.content} />
 			<div className='my-6 border-b-2 border-b-slate-200'></div>
 			<Giscus />
 		</>

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -9,9 +9,11 @@ import {
 export async function generateStaticParams() {
 	const slugs = await getPostSlugs();
 
-	return slugs?.map((item) => ({
-		slug: item.slug,
-	}));
+	return (
+		slugs?.map((item) => ({
+			slug: item.slug,
+		})) || []
+	);
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {

--- a/src/app/(blog)/blog/page.tsx
+++ b/src/app/(blog)/blog/page.tsx
@@ -1,14 +1,6 @@
-import { PostAbstract } from '@/src/interfaces/post';
 import PostAbstractList from '@/src/app/components/PostAbstractList';
 
-export default function Page() {
-	const dummyPosts: PostAbstract[] = Array.from({ length: 30 }, (_, i) => ({
-		title: `Item ${i + 1}`,
-		description: `Description for item ${i + 1}`,
-		createdAt: '2024. 07. 01',
-		slug: `item-${i + 1}`,
-	})); // 총 30개의 아이템 예시
-
+export default async function Page() {
 	return (
 		<>
 			<section className='mb-4 border-b-2 border-slate-300'>
@@ -18,7 +10,7 @@ export default function Page() {
 				</p>
 			</section>
 
-			<PostAbstractList posts={dummyPosts} />
+			<PostAbstractList />
 		</>
 	);
 }

--- a/src/app/(blog)/blog/page.tsx
+++ b/src/app/(blog)/blog/page.tsx
@@ -1,4 +1,4 @@
-import PostAbstractList from '@/src/app/components/PostAbstractList';
+import PostAbstractListWrapper from '../../components/PostAbstarctListWrapper';
 
 export default async function Page() {
 	return (
@@ -10,7 +10,7 @@ export default async function Page() {
 				</p>
 			</section>
 
-			<PostAbstractList />
+			<PostAbstractListWrapper />
 		</>
 	);
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'next/navigation';
-import { supabaseServer } from '@/src/utils/supabase/server';
+import { supabaseClient } from '@/src/utils/supabase/client';
 
 export default async function DashboardPage() {
-	const { data, error } = await supabaseServer.auth.getUser();
+	const { data, error } = await supabaseClient.auth.getUser();
 	if (error || !data?.user) {
 		redirect('/login');
 	}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation';
-import { supabaseClient } from '@/src/utils/supabase/client';
+import { createClient } from '@/src/utils/supabase/server';
 
 export default async function DashboardPage() {
-	const { data, error } = await supabaseClient.auth.getUser();
+	const supabase = createClient();
+	const { data, error } = await supabase.auth.getUser();
 	if (error || !data?.user) {
 		redirect('/login');
 	}

--- a/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
@@ -1,23 +1,32 @@
-import { POSTS_PATH } from '@/src/lib/constants';
 import PostHeader from '@/src/app/components/PostHeader';
 import PostBody from '@/src/app/components/PostBody';
+import {
+	getPostFromSlug,
+	getPostSlugs,
+} from '@/src/utils/supabase/clientActions';
 
-export function generateStaticParams() {
-	// const slugs = getPostSlugsFrom(POSTS_PATH);
-	// 	return slugs.map((slug) => ({
-	// 		slug: slug,
-	// 	}));
+export async function generateStaticParams() {
+	const slugs = await getPostSlugs();
+
+	return slugs?.map((item) => ({
+		slug: item.slug,
+	}));
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
+	const post = await getPostFromSlug(params.slug);
+
+	if (!post) {
+		return <div>Post not found</div>;
+	}
 	return (
-		<section className='m-auto py-6 md:max-w-5xl md:py-12'>
-			{/* <PostHeader
-				title={title}
-				dateString={dateString}
-				readingMinutes={readingMinutes}
-			/> */}
-			{/* <PostBody postContent={postContent} /> */}
+		<section className='m-auto py-6 md:max-w-3xl md:py-12'>
+			<PostHeader
+				title={post.title}
+				created_at={post.created_at}
+				reading_time={post.reading_time}
+			/>
+			<PostBody postContent={post.content} />
 		</section>
 	);
 }

--- a/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
@@ -8,9 +8,11 @@ import {
 export async function generateStaticParams() {
 	const slugs = await getPostSlugs();
 
-	return slugs?.map((item) => ({
-		slug: item.slug,
-	}));
+	return (
+		slugs?.map((item) => ({
+			slug: item.slug,
+		})) || []
+	);
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {

--- a/src/app/(dashboard)/dashboard/posts/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,4 +1,4 @@
-import Search from '@/src/app/components/Search';
+// import Search from '@/src/app/components/Search';
 import PostAbstractListWrapper from '@/src/app/components/PostAbstarctListWrapper';
 
 export default function Page() {
@@ -7,7 +7,7 @@ export default function Page() {
 			<h1 className='my-8 text-2xl font-semibold md:text-4xl'>
 				작성한 글 목록
 			</h1>
-			<Search placeholder={'글 검색하기...'} />
+			{/* <Search placeholder={'글 검색하기...'} /> */}
 			<PostAbstractListWrapper />
 		</section>
 	);

--- a/src/app/(dashboard)/dashboard/posts/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,5 +1,5 @@
 import Search from '@/src/app/components/Search';
-import PostAbstarctList from '@/src/app/components/PostAbstractList';
+import PostAbstractListWrapper from '@/src/app/components/PostAbstarctListWrapper';
 
 export default function Page() {
 	return (
@@ -8,7 +8,7 @@ export default function Page() {
 				작성한 글 목록
 			</h1>
 			<Search placeholder={'글 검색하기...'} />
-			<PostAbstarctList />
+			<PostAbstractListWrapper />
 		</section>
 	);
 }

--- a/src/app/(dashboard)/dashboard/posts/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/page.tsx
@@ -1,23 +1,14 @@
 import Search from '@/src/app/components/Search';
 import PostAbstarctList from '@/src/app/components/PostAbstractList';
 
-import { PostAbstract } from '@/src/interfaces/post';
-
 export default function Page() {
-	const dummyPosts: PostAbstract[] = Array.from({ length: 30 }, (_, i) => ({
-		title: `Item ${i + 1}`,
-		description: `Description for item ${i + 1}`,
-		createdAt: '2024. 07. 01',
-		slug: `item-${i + 1}`,
-	})); // 총 30개의 아이템 예시
-
 	return (
 		<section className='m-auto flex h-full flex-col md:max-w-3xl'>
 			<h1 className='my-8 text-2xl font-semibold md:text-4xl'>
 				작성한 글 목록
 			</h1>
 			<Search placeholder={'글 검색하기...'} />
-			<PostAbstarctList posts={dummyPosts} />
+			<PostAbstarctList />
 		</section>
 	);
 }

--- a/src/app/(dashboard)/dashboard/write/page.tsx
+++ b/src/app/(dashboard)/dashboard/write/page.tsx
@@ -14,7 +14,7 @@ interface ContentType {
 export default function Page() {
 	const [title, setTitle] = useState<string>('');
 	const [description, setDescription] = useState<string>('');
-	const [content, setContent] = useState<object>({});
+	const [content, setContent] = useState<string>('');
 	const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 	const router = useRouter();
 
@@ -28,7 +28,7 @@ export default function Page() {
 		setDescription(e.target.value);
 	};
 
-	const handleContentChange = (reason: object) => {
+	const handleContentChange = (reason: string) => {
 		setContent(reason);
 	};
 
@@ -96,7 +96,7 @@ export default function Page() {
 				<Tiptap
 					id='body'
 					content={content}
-					onChange={(newContent: object) => handleContentChange(newContent)}
+					onChange={(newContent: string) => handleContentChange(newContent)}
 				/>
 
 				<div className='my-4 flex justify-end gap-2'>

--- a/src/app/(dashboard)/dashboard/write/page.tsx
+++ b/src/app/(dashboard)/dashboard/write/page.tsx
@@ -37,7 +37,6 @@ export default function Page() {
 		const result = await createPostData(title, description, content);
 
 		if (result.success) {
-			console.log('Post created successfully:', result.data);
 			router.push('/dashboard');
 		} else {
 			console.error('Error creating post:', result.error);
@@ -56,8 +55,6 @@ export default function Page() {
 		setIsModalOpen(false);
 		router.back();
 	};
-
-	console.log({ title, description, content });
 
 	return (
 		<div className='m-auto flex h-full flex-col md:max-w-3xl'>

--- a/src/app/components/Loading.tsx
+++ b/src/app/components/Loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+	return <div>Loading...</div>;
+}

--- a/src/app/components/PostAbstarctListWrapper.tsx
+++ b/src/app/components/PostAbstarctListWrapper.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { Suspense } from 'react';
+import PostAbstractList from './PostAbstractList';
+import Loading from './Loading';
+
+export default function PostAbstractListWrapper() {
+	return (
+		<Suspense fallback={<Loading />}>
+			<PostAbstractList />
+		</Suspense>
+	);
+}

--- a/src/app/components/PostAbstractList.tsx
+++ b/src/app/components/PostAbstractList.tsx
@@ -4,26 +4,38 @@ import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
 import PostListItem from './PostListItem';
 import { PostAbstract } from '@/src/interfaces/post';
-
-interface DashboardPostAbstractListProps {
-	posts: PostAbstract[];
-}
+import { fetchPostAbstracts } from '@/src/utils/supabase/clientActions';
 
 const ITEMS_PER_PAGE = 10;
 
-export default function DashboardPostAbstractList({
-	posts,
-}: DashboardPostAbstractListProps) {
+export default function PostAbstractList() {
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const pathname = usePathname();
 
 	const currentPageFromUrl = Number(searchParams.get('page')) || 1;
 	const [currentPage, setCurrentPage] = useState(currentPageFromUrl);
+	const [posts, setPosts] = useState<PostAbstract[]>([]);
+	const [loading, setLoading] = useState<boolean>(true);
 
 	useEffect(() => {
 		setCurrentPage(currentPageFromUrl);
 	}, [currentPageFromUrl]);
+
+	useEffect(() => {
+		const fetchAbstracts = async (page: number) => {
+			setLoading(true);
+			const data = await fetchPostAbstracts(page, ITEMS_PER_PAGE);
+
+			if (data) {
+				setPosts(data);
+			}
+
+			setLoading(false);
+		};
+
+		fetchAbstracts(currentPage);
+	}, [currentPage]);
 
 	const totalPages = Math.ceil(posts.length / ITEMS_PER_PAGE);
 
@@ -34,13 +46,14 @@ export default function DashboardPostAbstractList({
 		setCurrentPage(page);
 	};
 
-	const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-	const selectedItems = posts.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+	if (loading) {
+		return <div>Loading...</div>;
+	}
 
 	return (
 		<div className='flex h-auto w-full flex-1 flex-col items-center'>
 			<ul className='mb-5 w-full list-none'>
-				{selectedItems.map((item, index) => (
+				{posts.map((item, index) => (
 					<li key={index} className='my-1'>
 						<PostListItem post={item} />
 					</li>

--- a/src/app/components/PostBody.tsx
+++ b/src/app/components/PostBody.tsx
@@ -1,3 +1,4 @@
+import '@/src/app/globals.css';
 interface PostBodyProps {
 	postContent: string;
 }

--- a/src/app/components/PostHeader.tsx
+++ b/src/app/components/PostHeader.tsx
@@ -2,14 +2,14 @@ import { CalendarDays, Clock } from 'lucide-react';
 
 interface PostHeaderProps {
 	title: string;
-	dateString: string;
-	readingMinutes: number;
+	created_at: string;
+	reading_time: number;
 }
 
 export default function PostHeader({
 	title,
-	dateString,
-	readingMinutes,
+	created_at,
+	reading_time,
 }: PostHeaderProps) {
 	return (
 		<section className='flex flex-col items-center border-b-2 border-slate-200 pb-1'>
@@ -19,11 +19,11 @@ export default function PostHeader({
 			<div className='flex gap-4 text-sm text-slate-500'>
 				<div className='flex items-center gap-0.5'>
 					<CalendarDays width={12} height={12} />
-					<span>{dateString}</span>
+					<span>{created_at}</span>
 				</div>
 				<div className='flex items-center gap-0.5'>
 					<Clock width={12} height={12} />
-					<span>{readingMinutes}분</span>
+					<span>{reading_time}분</span>
 				</div>
 			</div>
 		</section>

--- a/src/app/components/PostListItem.tsx
+++ b/src/app/components/PostListItem.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import { usePathname } from 'next/navigation';
 import { PostAbstract } from '@/src/interfaces/post';
 import { useState } from 'react';
@@ -50,7 +49,7 @@ export default function PostListItem({ post }: PostAbstractItemProps) {
 
 				<div className='mt-2 flex justify-between text-sm text-slate-400'>
 					<p>{post.description}</p>
-					<p>{post.createdAt}</p>
+					<p>{post.created_at}</p>
 				</div>
 			</article>
 

--- a/src/app/components/Tiptap.tsx
+++ b/src/app/components/Tiptap.tsx
@@ -29,7 +29,7 @@ lowlight.register('html', html);
 const Tiptap = ({ onChange, content }: any) => {
 	const editorContainerRef = useRef<HTMLDivElement>(null);
 
-	const handleChange = (newContent: object) => {
+	const handleChange = (newContent: string) => {
 		onChange(newContent);
 	};
 
@@ -61,7 +61,7 @@ const Tiptap = ({ onChange, content }: any) => {
 			},
 		},
 		onUpdate: ({ editor }) => {
-			handleChange(editor.getJSON());
+			handleChange(editor.getHTML());
 		},
 	});
 

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -2,9 +2,10 @@ export type Post = {
 	slug: string;
 	title: string;
 	description: string;
-	content: object;
+	content: string;
 	created_at: string;
 	updated_at: string;
+	reading_time: number;
 };
 
 export type PostAbstract = Pick<

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -72,7 +72,10 @@ export const getPostFromSlug = async (slug: string) => {
 		.from('posts')
 		.select('*')
 		.eq('slug', slug)
-		.single();
+		.limit(1)
+		.maybeSingle();
+
+	console.log(data);
 
 	if (error || !data) {
 		console.error('Error fetching post:', error || 'No data found');

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -1,16 +1,17 @@
+import readingTime from 'reading-time';
 import dayjs from 'dayjs';
 import { supabaseClient } from './client';
-import { Post } from '@/src/interfaces/post';
+import { Post, PostAbstract } from '@/src/interfaces/post';
 
 export const createPostData = async (
 	title: string,
 	description: string,
-	content: object
+	content: string
 ) => {
 	const slug = encodeURIComponent(title);
-
 	const created_at = dayjs().locale('ko').format('YYYY-MM-DD');
 	const updated_at = created_at;
+	const reading_time = Math.ceil(readingTime(content).minutes);
 
 	const postData: Post = {
 		slug,
@@ -19,6 +20,7 @@ export const createPostData = async (
 		content,
 		created_at,
 		updated_at,
+		reading_time,
 	};
 
 	const { data, error } = await supabaseClient
@@ -32,4 +34,51 @@ export const createPostData = async (
 	}
 
 	return { success: true, data };
+};
+
+export const fetchPostAbstracts = async (
+	page: number,
+	itemsPerPage: number
+): Promise<PostAbstract[] | null> => {
+	const from = (page - 1) * itemsPerPage;
+	const to = page * itemsPerPage - 1;
+
+	const { data, error } = await supabaseClient
+		.from('posts')
+		.select('slug, title, description, created_at')
+		.range(from, to);
+
+	if (error) {
+		console.error('게시글 불러오기 실패:', error);
+		return null;
+	}
+
+	return data;
+};
+
+export const getPostSlugs = async () => {
+	const { data, error } = await supabaseClient.from('posts').select('slug');
+
+	if (error) {
+		console.error('오류가 발생했습니다:', error);
+		return null;
+	}
+
+	return data;
+};
+
+export const getPostFromSlug = async (slug: string) => {
+	const { data, error } = await supabaseClient
+		.from('posts')
+		.select('*')
+		.eq('slug', slug)
+		.single();
+
+	if (error) {
+		console.error('오류가 발생했습니다:', error);
+		return null;
+	}
+
+	console.log(data);
+	return data;
 };

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -75,10 +75,15 @@ export const getPostFromSlug = async (slug: string) => {
 		.limit(1)
 		.maybeSingle();
 
-	console.log(data);
+	console.log('Data fetched for slug:', slug, data);
 
-	if (error || !data) {
-		console.error('Error fetching post:', error || 'No data found');
+	if (error) {
+		console.error('Error fetching post:', error.message);
+		return null;
+	}
+
+	if (!data) {
+		console.error('No data found for slug:', slug);
 		return null;
 	}
 

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -48,8 +48,8 @@ export const fetchPostAbstracts = async (
 		.select('slug, title, description, created_at')
 		.range(from, to);
 
-	if (error) {
-		console.error('게시글 불러오기 실패:', error);
+	if (error || !data || data.length === 0) {
+		console.error('게시글 불러오기 실패:', error || 'No data found');
 		return null;
 	}
 
@@ -74,11 +74,10 @@ export const getPostFromSlug = async (slug: string) => {
 		.eq('slug', slug)
 		.single();
 
-	if (error) {
-		console.error('오류가 발생했습니다:', error);
+	if (error || !data) {
+		console.error('Error fetching post:', error || 'No data found');
 		return null;
 	}
 
-	console.log(data);
 	return data;
 };

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,7 +1,7 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
-function createClient() {
+export function createClient() {
 	const cookieStore = cookies();
 
 	return createServerClient(
@@ -26,5 +26,3 @@ function createClient() {
 		}
 	);
 }
-
-export const supabaseServer = createClient();

--- a/src/utils/supabase/serverActions.ts
+++ b/src/utils/supabase/serverActions.ts
@@ -1,16 +1,18 @@
 'use server';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { supabaseServer } from './server';
+import { createClient } from './server';
 
 export async function login(formData: FormData) {
+	const supabase = createClient();
+
 	const data = {
 		email: formData.get('email') as string,
 		password: formData.get('password') as string,
 	};
 
 	// login data 포함시켜서 로직 처리 수정할 것
-	const { error } = await supabaseServer.auth.signInWithPassword(data);
+	const { error } = await supabase.auth.signInWithPassword(data);
 
 	if (error) {
 		redirect('/error');
@@ -21,7 +23,8 @@ export async function login(formData: FormData) {
 }
 
 export async function signout() {
-	const { error } = await supabaseServer.auth.signOut();
+	const supabase = createClient();
+	const { error } = await supabase.auth.signOut();
 
 	if (error) {
 		redirect('/error');
@@ -32,9 +35,10 @@ export async function signout() {
 }
 
 export async function getUserData() {
+	const supabase = createClient();
 	const {
 		data: { user },
-	} = await supabaseServer.auth.getUser();
+	} = await supabase.auth.getUser();
 
 	return user;
 }

--- a/src/utils/supabase/serverActions.ts
+++ b/src/utils/supabase/serverActions.ts
@@ -1,5 +1,4 @@
 'use server';
-
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { supabaseServer } from './server';


### PR DESCRIPTION
> 관련 이슈: #11 

## 전달 사항
본 이슈에서는 게시글 읽기 기능 구현 작업을 진행했습니다.

## 주요 변경 사항
### clientActions
게시글 데이터를 읽어오는 로직을 추가했습니다.
- `fetchPostAbstracts`: 게시글 목록 정보를 불러옵니다.
- `getPostSlugs`: 게시글 페이지의 정적 렌더링을 위한 slugs 정보를 블러옵니다.
- `getPostFromSlug`: slug로부터 게시글 상세 정보를 불러옵니다.
### Post 타입 변경
기존의 content 타입을 JSON에서 HTML로 변경했습니다.
### PostAbstractList
Suspense 기능을 추가해 빌드 시 발생하던 오류를 해결했습니다.
관련 이슈: #9 

## 추후 작업
게시글 수정 기능 구현
