### PR TITLE
Feat: 게시글 수정 기능 구현 #13

### DIFF
--- a/src/app/(dashboard)/dashboard/write/page.tsx
+++ b/src/app/(dashboard)/dashboard/write/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Tiptap from '@/src/app/components/Tiptap';
 import Modal from '@/src/app/components/Modal';
@@ -10,7 +10,7 @@ import {
 } from '@/src/utils/supabase/clientActions';
 import { Post } from '@/src/interfaces/post';
 
-export default function Page() {
+function WritePageContent() {
 	const [title, setTitle] = useState<string>('');
 	const [description, setDescription] = useState<string>('');
 	const [content, setContent] = useState<string>('');
@@ -153,5 +153,13 @@ export default function Page() {
 				</p>
 			</Modal>
 		</div>
+	);
+}
+
+export default function Page() {
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<WritePageContent />
+		</Suspense>
 	);
 }

--- a/src/app/components/PostListItem.tsx
+++ b/src/app/components/PostListItem.tsx
@@ -40,9 +40,12 @@ export default function PostListItem({ post }: PostAbstractItemProps) {
 							>
 								삭제
 							</button>
-							<button className='rounded-md border-sky-500 bg-sky-500 px-2 py-1 text-sm font-medium text-white hover:bg-sky-300'>
+							<Link
+								className='rounded-md border-sky-500 bg-sky-500 px-2 py-1 text-sm font-medium text-white hover:bg-sky-300'
+								href={`/dashboard/write?slug=${encodeURIComponent(post.slug)}`}
+							>
 								수정
-							</button>
+							</Link>
 						</div>
 					)}
 				</div>

--- a/src/app/components/Tiptap.tsx
+++ b/src/app/components/Tiptap.tsx
@@ -34,6 +34,7 @@ const Tiptap = ({ onChange, content }: any) => {
 	};
 
 	const editor = useEditor({
+		content: content,
 		extensions: [
 			StarterKit.configure({
 				codeBlock: false,

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -36,6 +36,37 @@ export const createPostData = async (
 	return { success: true, data };
 };
 
+export const updatePostData = async (
+	slug: string,
+	title: string,
+	description: string,
+	content: string
+) => {
+	const updated_at = dayjs().locale('ko').format('YYYY-MM-DD');
+	const reading_time = Math.ceil(readingTime(content).minutes);
+
+	const postData = {
+		title,
+		description,
+		content,
+		updated_at,
+		reading_time,
+	};
+
+	const { data, error } = await supabaseClient
+		.from('posts')
+		.update(postData)
+		.eq('slug', slug)
+		.select();
+
+	if (error) {
+		console.error('Error updating post:', error);
+		return { success: false, error };
+	}
+
+	return { success: true, data };
+};
+
 export const fetchPostAbstracts = async (
 	page: number,
 	itemsPerPage: number


### PR DESCRIPTION
> 관련 이슈: #13 

## 전달 사항
게시글을 수정할 수 있는 기능을 구현했습니다.

## 주요 변경 사항
### clientActions
- `updatePostData`: 게시글을 수정해 supabase에 업로드합니다.

### 게시글 작성 페이지
- `searchParams`를 사용해 새 글 작성 / 기존 글 수정 기능을 분리했습니다.
- suspense를 사용해 에러 바운더리를 설정했습니다.


## 추후 작업
게시글 삭제 기능 구현
