### PR TITLE
Feat: 게시글 삭제 기능 구현 #15

### DIFF
--- a/src/app/components/PostAbstractList.tsx
+++ b/src/app/components/PostAbstractList.tsx
@@ -16,34 +16,40 @@ export default function PostAbstractList() {
 	const currentPageFromUrl = Number(searchParams.get('page')) || 1;
 	const [currentPage, setCurrentPage] = useState(currentPageFromUrl);
 	const [posts, setPosts] = useState<PostAbstract[]>([]);
+	const [totalPosts, setTotalPosts] = useState<number>(0);
 	const [loading, setLoading] = useState<boolean>(true);
 
 	useEffect(() => {
 		setCurrentPage(currentPageFromUrl);
 	}, [currentPageFromUrl]);
 
+	const fetchData = async (page: number) => {
+		setLoading(true);
+		const data = await fetchPostAbstracts(page, ITEMS_PER_PAGE);
+
+		if (data) {
+			setPosts(data.posts);
+			setTotalPosts(data.totalPosts);
+		}
+
+		setLoading(false);
+	};
+
 	useEffect(() => {
-		const fetchAbstracts = async (page: number) => {
-			setLoading(true);
-			const data = await fetchPostAbstracts(page, ITEMS_PER_PAGE);
-
-			if (data) {
-				setPosts(data);
-			}
-
-			setLoading(false);
-		};
-
-		fetchAbstracts(currentPage);
+		fetchData(currentPage);
 	}, [currentPage]);
 
-	const totalPages = Math.ceil(posts.length / ITEMS_PER_PAGE);
+	const totalPages = Math.ceil(totalPosts / ITEMS_PER_PAGE);
 
 	const handlePageChange = (page: number) => {
 		const params = new URLSearchParams(searchParams.toString());
 		params.set('page', page.toString());
 		router.replace(`${pathname}?${params.toString()}`);
 		setCurrentPage(page);
+	};
+
+	const handlePostDeleted = () => {
+		fetchData(currentPage);
 	};
 
 	if (loading) {
@@ -55,7 +61,7 @@ export default function PostAbstractList() {
 			<ul className='mb-5 w-full list-none'>
 				{posts.map((item, index) => (
 					<li key={index} className='my-1'>
-						<PostListItem post={item} />
+						<PostListItem post={item} onPostDeleted={handlePostDeleted} />
 					</li>
 				))}
 			</ul>

--- a/src/app/components/PostListItem.tsx
+++ b/src/app/components/PostListItem.tsx
@@ -2,23 +2,33 @@
 import { usePathname } from 'next/navigation';
 import { PostAbstract } from '@/src/interfaces/post';
 import { useState } from 'react';
+import { deletePostData } from '@/src/utils/supabase/clientActions';
 import Link from 'next/link';
 import Modal from './Modal';
 
 interface PostAbstractItemProps {
 	post: PostAbstract;
+	onPostDeleted: () => void;
 }
 
-export default function PostListItem({ post }: PostAbstractItemProps) {
+export default function PostListItem({
+	post,
+	onPostDeleted,
+}: PostAbstractItemProps) {
 	const pathname = usePathname();
 	const isDashboard = pathname.startsWith('/dashboard');
 	const [isModalOpen, setIsModalOpen] = useState(false);
 
 	const openModal = () => setIsModalOpen(true);
 	const closeModal = () => setIsModalOpen(false);
-	const deletePost = () => {
-		// 여기에 삭제 로직 추가
-		console.log('게시글 삭제 완료');
+	const deletePost = async () => {
+		const result = await deletePostData(post.id);
+		if (result.success) {
+			console.log('게시글 삭제 완료');
+			onPostDeleted();
+		} else {
+			console.error('Error deleting post:', result.error);
+		}
 		closeModal();
 	};
 

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -11,4 +11,4 @@ export type Post = {
 export type PostAbstract = Pick<
 	Post,
 	'title' | 'description' | 'created_at' | 'slug'
->;
+> & { id: number };

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -67,24 +67,35 @@ export const updatePostData = async (
 	return { success: true, data };
 };
 
+export const deletePostData = async (id: number) => {
+	const { error } = await supabaseClient.from('posts').delete().eq('id', id);
+
+	if (error) {
+		console.error('게시글 삭제에 실패했습니다:', error);
+		return { success: false, error };
+	}
+
+	return { success: true };
+};
+
 export const fetchPostAbstracts = async (
 	page: number,
 	itemsPerPage: number
-): Promise<PostAbstract[] | null> => {
+): Promise<{ posts: PostAbstract[]; totalPosts: number } | null> => {
 	const from = (page - 1) * itemsPerPage;
 	const to = page * itemsPerPage - 1;
 
-	const { data, error } = await supabaseClient
+	const { data, error, count } = await supabaseClient
 		.from('posts')
-		.select('slug, title, description, created_at')
+		.select('id, slug, title, description, created_at', { count: 'exact' })
 		.range(from, to);
 
-	if (error || !data || data.length === 0) {
+	if (error || !data) {
 		console.error('게시글 불러오기 실패:', error || 'No data found');
 		return null;
 	}
 
-	return data;
+	return { posts: data, totalPosts: count || 0 };
 };
 
 export const getPostSlugs = async () => {


### PR DESCRIPTION
> 관련 이슈: #15 

## 전달 사항
본 이슈에서는 게시글 삭제 기능을 구현하고, 페이지네이션에서 발생한 버그를 해결했습니다.

## 주요 변경 사항
### PostAbstractList
페이지네이션이 정상적으로 진행되지 않던 버그를 수정했습니다. 현재 목록에 표시될 게시글 수를 구하는 기존 로직에서, 현재 페이지에 대한 게시글 목록과 전체 게시글 수를 기반으로 총 페이지를 계산하도록 했습니다.

### PostListItem
게시글 삭제 버튼을 클릭 시 게시글을 삭제하고, 게시글 목록을 업데이트하는 로직을 구현했습니다.

## 추후 작업
검색 기능 추가
