### PR TITLE
Bug: 게시글 url 관련 이슈 #17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"@tiptap/pm": "^2.4.0",
 				"@tiptap/react": "^2.4.0",
 				"@tiptap/starter-kit": "^2.4.0",
+				"@types/uuid": "^10.0.0",
 				"dayjs": "^1.11.11",
 				"gray-matter": "^4.0.3",
 				"highlight.js": "^11.9.0",
@@ -50,7 +51,8 @@
 				"remark-parse": "^11.0.0",
 				"remark-rehype": "^11.1.0",
 				"shiki": "^1.5.1",
-				"unified": "^11.0.4"
+				"unified": "^11.0.4",
+				"uuid": "^10.0.0"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^19.3.0",
@@ -1834,6 +1836,12 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
 			"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
 			"license": "MIT"
 		},
 		"node_modules/@types/ws": {
@@ -15821,6 +15829,19 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/uvu": {
 			"version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"@tiptap/pm": "^2.4.0",
 		"@tiptap/react": "^2.4.0",
 		"@tiptap/starter-kit": "^2.4.0",
+		"@types/uuid": "^10.0.0",
 		"dayjs": "^1.11.11",
 		"gray-matter": "^4.0.3",
 		"highlight.js": "^11.9.0",
@@ -63,7 +64,8 @@
 		"remark-parse": "^11.0.0",
 		"remark-rehype": "^11.1.0",
 		"shiki": "^1.5.1",
-		"unified": "^11.0.4"
+		"unified": "^11.0.4",
+		"uuid": "^10.0.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.3.0",

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -17,7 +17,7 @@ export async function generateStaticParams() {
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
-	const post = await getPostFromSlug(params.slug);
+	const post = await getPostFromSlug(decodeURIComponent(params.slug));
 
 	if (!post) {
 		return <div>Post not found</div>;

--- a/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
@@ -16,7 +16,6 @@ export async function generateStaticParams() {
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
-	console.log(params);
 	const post = await getPostFromSlug(decodeURIComponent(params.slug));
 
 	if (!post) {

--- a/src/app/components/PostListItem.tsx
+++ b/src/app/components/PostListItem.tsx
@@ -32,16 +32,11 @@ export default function PostListItem({
 		closeModal();
 	};
 
-	console.log(post.slug);
-
 	return (
 		<>
 			<article className='mb-4 border-b-2 border-slate-50'>
 				<div className='flex justify-between'>
-					<Link
-						className='text-lg'
-						href={`${pathname}/` + encodeURIComponent(post.slug)}
-					>
+					<Link className='text-lg' href={`${pathname}/` + post.slug}>
 						{post.title}
 					</Link>
 					{isDashboard && (
@@ -57,7 +52,7 @@ export default function PostListItem({
 							</button>
 							<Link
 								className='rounded-md border-sky-500 bg-sky-500 px-2 py-1 text-sm font-medium text-white hover:bg-sky-300'
-								href={`/dashboard/write?slug=${encodeURIComponent(post.slug)}`}
+								href={`/dashboard/write?slug=${post.slug}`}
 							>
 								수정
 							</Link>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,58 +1,9 @@
-import dayjs from 'dayjs';
-import { Post, PostAbstract } from '@/src/interfaces/post';
+export const customSlugify = (text: string): string => {
+	let filteredText = text
+		.replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9\s]/g, '')
+		.toLowerCase();
 
-// 게시글 상세 정보 불러오기
-// export function getPostBySlug(slug: string, postDirectory: string) {
-// 	const realSlug = slug.replace(/\.md$/, '');
-// 	const fullPath = join(postDirectory, `${realSlug}.md`);
-// 	const postContents = fs.readFileSync(fullPath, 'utf8');
-// 	const { data, content } = matter(postContents);
-// 	const readingMinutes = Math.ceil(readingTime(content).minutes);
-// 	const dateString = dayjs(data.date).locale('ko').format('YYYY년 MM월 DD일');
-// 	return {
-// 		...data,
-// 		readingMinutes,
-// 		createdAt,
-//     updatedAt
-// 		slug: realSlug,
-// 		content,
-// 	} as Post;
-// }
+	filteredText = filteredText.replace(/\s+/g, '-');
 
-// 포스트 요약 정보 (url, slug, description)만 불러오기
-// export function getPostAbstracts(postDirectory: string) {
-// 	const files = getPostSlugsFrom(postDirectory);
-// 	const postAbstracts: PostAbstract[] = [];
-
-// 	files.forEach((file) => {
-// 		const post = getPostBySlug(file, postDirectory);
-// 		const { title, description, dateString, slug } = post;
-
-// 		postAbstracts.push({
-// 			title,
-// 			description,
-// 			dateString,
-// 			slug,
-// 		});
-// 	});
-
-// 	return postAbstracts;
-// }
-
-// 마크다운 콘텐츠를 HTML 파일로 변환하기
-// export async function markdownToHTML(content: string) {
-// 	const htmlContent = await unified()
-// 		.use(remarkParse)
-// 		.use(remarkGfm)
-// 		.use(remarkGithub)
-// 		.use(remarkBreaks)
-// 		.use(remarkRehype)
-// 		.use(rehypeFormat)
-// 		.use(rehypeSlug)
-// 		.use(rehypeAutolinkHeadings)
-// 		.use(rehypePrettyCode)
-// 		.use(rehypeStringify)
-// 		.process(content);
-
-// 	return htmlContent.toString();
-// }
+	return filteredText;
+};

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,0 @@
-import { join } from 'path';
-
-const BASE_DIR = process.cwd();
-export const POSTS_PATH = join(BASE_DIR, '/src/posts/blog');
-export const CRAFTS_PATH = join(BASE_DIR, '/src/posts/craft');

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -2,16 +2,17 @@ import readingTime from 'reading-time';
 import dayjs from 'dayjs';
 import { supabaseClient } from './client';
 import { Post, PostAbstract } from '@/src/interfaces/post';
+import { customSlugify } from '@/src/lib/api';
+import { v4 as uuidv4 } from 'uuid';
 
 export const createPostData = async (
 	title: string,
 	description: string,
 	content: string
 ) => {
-	const slug = encodeURIComponent(title);
-	console.log('인코딩된 slug: ', slug);
-	const decodedSlug = decodeURIComponent(slug);
-	console.log('디코딩된 slug: ', decodedSlug);
+	const baseSlug = customSlugify(title);
+	const slug = `${baseSlug}-${uuidv4()}`;
+
 	const created_at = dayjs().locale('ko').format('YYYY-MM-DD');
 	const updated_at = created_at;
 	const reading_time = Math.ceil(readingTime(content).minutes);
@@ -32,7 +33,7 @@ export const createPostData = async (
 		.select();
 
 	if (error) {
-		console.error('Error creating post:', error);
+		console.error('게시글 생성 실패:', error);
 		return { success: false, error };
 	}
 


### PR DESCRIPTION
> 관련 이슈: #17 

## 전달 사항
게시글 URL과 관련된 버그가 있어 이를 해결했습니다.

## 주요 변경 사항
### clientActions
- `createPostData`: 이제 게시글을 작성할 때 slug는 고유성을 보장하기 위해서 baseSlug과 uuid를 결합한 형태로 저장됩니다.
### api
- `customSlugify`: 게시글 제목의 slug 처리를 slugify라는 라이브러를 사용해 처리하려고 했지만, 한글의 경우 올바르게 slug로 변환할 수 없는 문제가 있었습니다. 따라서 정규표현식을 사용해 slug로 변환할 수 있도록 했습니다.

## 추후 작업
- 검색 기능 구현