### PR TITLE
Refactor: 게시글 데이터 구조 변경 #29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
 				"react": "^18",
 				"react-dom": "^18",
 				"react-hook-form": "^7.52.0",
-				"reading-time": "^1.5.0",
 				"use-debounce": "^10.0.1",
 				"uuid": "^10.0.0"
 			},
@@ -6841,12 +6840,6 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
-		},
-		"node_modules/reading-time": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
-			"integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
-			"license": "MIT"
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"react": "^18",
 		"react-dom": "^18",
 		"react-hook-form": "^7.52.0",
-		"reading-time": "^1.5.0",
 		"use-debounce": "^10.0.1",
 		"uuid": "^10.0.0"
 	},

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -12,11 +12,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
 	return (
 		<>
-			<PostHeader
-				title={post.title}
-				created_at={post.created_at}
-				reading_time={post.reading_time}
-			/>
+			<PostHeader title={post.title} created_at={post.created_at} />
 			<PostBody postContent={post.content} />
 			<div className='my-6 border-b-2 border-b-slate-200'></div>
 			<Giscus />

--- a/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
+++ b/src/app/(dashboard)/dashboard/posts/[slug]/page.tsx
@@ -10,11 +10,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 	}
 	return (
 		<section className='m-auto py-6 md:max-w-3xl md:py-12'>
-			<PostHeader
-				title={post.title}
-				created_at={post.created_at}
-				reading_time={post.reading_time}
-			/>
+			<PostHeader title={post.title} created_at={post.created_at} />
 			<PostBody postContent={post.content} />
 		</section>
 	);

--- a/src/app/components/PostHeader.tsx
+++ b/src/app/components/PostHeader.tsx
@@ -1,30 +1,19 @@
-import { CalendarDays, Clock } from 'lucide-react';
+import { CalendarDays } from 'lucide-react';
 
 interface PostHeaderProps {
 	title: string;
 	created_at: string;
-	reading_time: number;
 }
 
-export default function PostHeader({
-	title,
-	created_at,
-	reading_time,
-}: PostHeaderProps) {
+export default function PostHeader({ title, created_at }: PostHeaderProps) {
 	return (
 		<section className='flex flex-col items-center border-b-2 border-slate-200 pb-1'>
 			<h1 className='mb-2 text-xl sm:text-2xl md:text-3xl lg:text-4xl'>
 				{title}
 			</h1>
-			<div className='flex gap-4 text-sm text-slate-500'>
-				<div className='flex items-center gap-0.5'>
-					<CalendarDays width={12} height={12} />
-					<span>{created_at}</span>
-				</div>
-				<div className='flex items-center gap-0.5'>
-					<Clock width={12} height={12} />
-					<span>{reading_time}분</span>
-				</div>
+			<div className='flex items-center gap-4 text-sm text-slate-500'>
+				<CalendarDays width={12} height={12} />
+				<span>{created_at}</span>
 			</div>
 		</section>
 	);

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -4,7 +4,6 @@ export type Post = {
 	description: string;
 	content: string;
 	created_at: string;
-	updated_at: string;
 };
 
 export type PostAbstract = Pick<

--- a/src/interfaces/post.ts
+++ b/src/interfaces/post.ts
@@ -5,7 +5,6 @@ export type Post = {
 	content: string;
 	created_at: string;
 	updated_at: string;
-	reading_time: number;
 };
 
 export type PostAbstract = Pick<

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -13,7 +13,6 @@ export const createPostData = async (
 	const slug = `${baseSlug}-${uuidv4()}`;
 
 	const created_at = dayjs().locale('ko').format('YYYY-MM-DD');
-	const updated_at = created_at;
 
 	const postData: Post = {
 		slug,
@@ -21,7 +20,6 @@ export const createPostData = async (
 		description,
 		content,
 		created_at,
-		updated_at,
 	};
 
 	const { data, error } = await supabaseClient
@@ -43,13 +41,10 @@ export const updatePostData = async (
 	description: string,
 	content: string
 ) => {
-	const updated_at = dayjs().locale('ko').format('YYYY-MM-DD');
-
 	const postData = {
 		title,
 		description,
 		content,
-		updated_at,
 	};
 
 	const { data, error } = await supabaseClient

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -1,4 +1,3 @@
-import readingTime from 'reading-time';
 import dayjs from 'dayjs';
 import { supabaseClient } from './client';
 import { Post } from '@/src/interfaces/post';
@@ -15,7 +14,6 @@ export const createPostData = async (
 
 	const created_at = dayjs().locale('ko').format('YYYY-MM-DD');
 	const updated_at = created_at;
-	const reading_time = Math.ceil(readingTime(content).minutes);
 
 	const postData: Post = {
 		slug,
@@ -24,7 +22,6 @@ export const createPostData = async (
 		content,
 		created_at,
 		updated_at,
-		reading_time,
 	};
 
 	const { data, error } = await supabaseClient
@@ -47,14 +44,12 @@ export const updatePostData = async (
 	content: string
 ) => {
 	const updated_at = dayjs().locale('ko').format('YYYY-MM-DD');
-	const reading_time = Math.ceil(readingTime(content).minutes);
 
 	const postData = {
 		title,
 		description,
 		content,
 		updated_at,
-		reading_time,
 	};
 
 	const { data, error } = await supabaseClient


### PR DESCRIPTION
> 관련 이슈: #29 

## 전달 사항
본 이슈에서는 게시글 데이터를 변경하고 이를 기반으로 컴포넌트를 갱신합니다.

## 주요 변경 사항
- 게시글 데이터 타입에서 reading_time, updated_at이 삭제되었습니다.
- reading-time 라이브러리를 삭제했습니다.
- 이를 기반으로 기존의 데이터 구조를 사용하던 컴포넌트를 갱신했습니다.

## 추후 작업
next-themes ThemeProvider 컴포넌트 관련 오류 해결 예정
