### PR TITLE
Fix: next-themes ThemeProvider 관련 경고 해결

### DIFF
--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -1,7 +1,7 @@
 import localFont from 'next/font/local';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-import { ThemeProvider } from 'next-themes';
+import Providers from '../components/Providers';
 import '../globals.css';
 
 const pretendard_var = localFont({
@@ -19,13 +19,13 @@ export default function BlogRootLayout({
 			<body
 				className={`${pretendard_var.className} flex h-screen flex-col antialiased`}
 			>
-				<ThemeProvider attribute='class'>
+				<Providers>
 					<Header></Header>
 					<main className=' m-auto mt-5  w-full max-w-3xl flex-1 px-5 md:w-[calc(100%-4rem)] md:max-w-3xl md:px-0 xl:w-[calc(100%-30rem)]'>
 						{children}
 					</main>
 					<Footer></Footer>
-				</ThemeProvider>
+				</Providers>
 			</body>
 		</html>
 	);

--- a/src/app/components/Providers.tsx
+++ b/src/app/components/Providers.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ThemeProvider } from 'next-themes';
+
+const Providers = ({ children }: { children: React.ReactNode }) => {
+	const [isMount, setMount] = useState(false);
+
+	useEffect(() => {
+		setMount(true);
+	}, []);
+
+	if (!isMount) {
+		return null;
+	}
+
+	return <ThemeProvider attribute='class'>{children}</ThemeProvider>;
+};
+
+export default Providers;


### PR DESCRIPTION
> 관련 이슈: #31 

## 전달 사항
본 PR에서는 next-themes의 ThemeProvider를 사용해 구현한 다크 모드 기능과 관련된 경고를 해결했습니다.

## 주요 변경 사항
![다크 테마 오류](https://github.com/user-attachments/assets/8b5a597b-3edd-473a-9aba-44c125f8348e)
페이지 컴포넌트 렌더링 시 발생하는 위 오류는 SSR과 CSR 사이의 불일치로 인해 발생하는 것으로 확인됐습니다. 따라서 이를 해결하기 위해 ThemeProvider의 마운트 상태를 확인하고 렌더링하는 Providers 컴포넌트를 구현해 해결했습니다.

## 추후 작업
게시글 목록 UI 레이아웃 수정 작업