### PR TITLE
Design: 게시글 목록 컴포넌트 레이아웃 수정 #33

### DIFF
--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import PostHeader from '../../../components/PostHeader';
 import PostBody from '../../../components/PostBody';
 import Giscus from '../../../components/Giscus';
+import dayjs from 'dayjs';
 import { getPostFromSlug } from '@/src/utils/supabase/serverActions';
 
 export default async function Page({ params }: { params: { slug: string } }) {
@@ -12,7 +13,10 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
 	return (
 		<>
-			<PostHeader title={post.title} created_at={post.created_at} />
+			<PostHeader
+				title={post.title}
+				created_at={dayjs(post.created_at).format('YYYY년 MM월 DD일')}
+			/>
 			<PostBody postContent={post.content} />
 			<div className='my-6 border-b-2 border-b-slate-200'></div>
 			<Giscus />

--- a/src/app/(blog)/blog/page.tsx
+++ b/src/app/(blog)/blog/page.tsx
@@ -14,9 +14,9 @@ export default function Page({
 
 	return (
 		<section>
-			<div className='mb-4 border-b-2 border-slate-300'>
+			<div className='mb-2 pb-2'>
 				<h1 className='mb-2 text-3xl font-semibold'>Blog</h1>
-				<p className='text-slate-500'>
+				<p className='text-slate-700 dark:text-slate-300'>
 					회고부터 유용한 지식까지, 기록을 통해 발전합니다.
 				</p>
 			</div>

--- a/src/app/(blog)/page.tsx
+++ b/src/app/(blog)/page.tsx
@@ -62,7 +62,7 @@ export default function Home() {
 				</div>
 			</section>
 			<section className='flex flex-col'>
-				<h2 className='mb-8 text-2xl font-semibold md:text-3xl'>
+				<h2 className='mb-4 text-2xl font-semibold md:text-3xl'>
 					📄 최근 포스트
 				</h2>
 				<LatestPost />

--- a/src/app/(login)/layout.tsx
+++ b/src/app/(login)/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 import localFont from 'next/font/local';
 import '@/src/app/globals.css';
-import { ThemeProvider } from 'next-themes';
+import Providers from '../components/Providers';
 
 const pretendard_var = localFont({
 	src: '../../../public/fonts/pretendard_variable.woff2',
@@ -18,7 +18,7 @@ export default function DashboardLayout({
 			<body
 				className={`${pretendard_var.className} m-auto min-h-dvh px-4 antialiased md:max-w-4xl`}
 			>
-				<ThemeProvider attribute='class'>{children}</ThemeProvider>
+				<Providers>{children}</Providers>
 			</body>
 		</html>
 	);

--- a/src/app/components/LatestPost.tsx
+++ b/src/app/components/LatestPost.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { fetchLatestPost } from '@/src/utils/supabase/serverActions';
+import dayjs from 'dayjs';
 
 export default function LatestPost() {
 	const [latestPost, setLatestPost] = useState<any>(null);
@@ -17,13 +18,13 @@ export default function LatestPost() {
 	return (
 		<>
 			{latestPost ? (
-				<article className='mb-10 flex flex-col justify-center px-8'>
+				<article className='mb-10 flex flex-col justify-center px-10'>
 					<Link className='text-lg' href={`blog/${latestPost.slug}`}>
 						{latestPost.title}
 					</Link>
 
 					<p className='mt-2 flex justify-between text-sm text-slate-400'>
-						{latestPost.description}
+						{dayjs(latestPost.created_at).format('YYYY년 MM월 DD일')}
 					</p>
 				</article>
 			) : (

--- a/src/app/components/PostAbstractList.tsx
+++ b/src/app/components/PostAbstractList.tsx
@@ -5,6 +5,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
 import PostListItem from './PostListItem';
 import { PostAbstract } from '@/src/interfaces/post';
 import { fetchPostAbstracts } from '@/src/utils/supabase/serverActions';
+import { PostListSkeleton } from './skeletons/PostListSkeleton';
 
 const ITEMS_PER_PAGE = 10;
 
@@ -53,7 +54,12 @@ export default function PostAbstractList({
 	};
 
 	if (loading) {
-		return <div>Loading...</div>;
+		return (
+			<PostListSkeleton
+				itemsCount={ITEMS_PER_PAGE}
+				isDashboard={pathname.startsWith('/dashboard')}
+			/>
+		);
 	}
 
 	return (

--- a/src/app/components/PostBody.tsx
+++ b/src/app/components/PostBody.tsx
@@ -6,7 +6,7 @@ interface PostBodyProps {
 export default function PostBody({ postContent }: PostBodyProps) {
 	return (
 		<section
-			className='prose mb-2'
+			className='prose mb-2 dark:text-white'
 			dangerouslySetInnerHTML={{ __html: postContent }}
 		></section>
 	);

--- a/src/app/components/PostHeader.tsx
+++ b/src/app/components/PostHeader.tsx
@@ -11,7 +11,7 @@ export default function PostHeader({ title, created_at }: PostHeaderProps) {
 			<h1 className='mb-2 text-xl sm:text-2xl md:text-3xl lg:text-4xl'>
 				{title}
 			</h1>
-			<div className='flex items-center gap-4 text-sm text-slate-500'>
+			<div className='flex items-center gap-1 text-sm text-slate-500 dark:text-slate-100'>
 				<CalendarDays width={12} height={12} />
 				<span>{created_at}</span>
 			</div>

--- a/src/app/components/PostListItem.tsx
+++ b/src/app/components/PostListItem.tsx
@@ -3,6 +3,7 @@ import { usePathname } from 'next/navigation';
 import { PostAbstract } from '@/src/interfaces/post';
 import { useState } from 'react';
 import { deletePostData } from '@/src/utils/supabase/clientActions';
+import dayjs from 'dayjs';
 import Link from 'next/link';
 import Modal from './Modal';
 
@@ -34,36 +35,34 @@ export default function PostListItem({
 
 	return (
 		<>
-			<article className='mb-4 border-b-2 border-gray-400 pb-2 dark:border-white'>
-				<div className='flex justify-between'>
+			<article className='mb-8 flex'>
+				<div className='flex-1'>
 					<Link className='text-lg' href={`${pathname}/` + post.slug}>
 						{post.title}
 					</Link>
-					{isDashboard && (
-						<div className='flex gap-2'>
-							<button
-								className='rounded-md border-red-500 bg-red-500 px-2 py-1 text-sm font-medium text-white hover:bg-red-300'
-								onClick={(e) => {
-									e.preventDefault();
-									openModal();
-								}}
-							>
-								삭제
-							</button>
-							<Link
-								className='rounded-md border-sky-500 bg-sky-500 px-2 py-1 text-sm font-medium text-white hover:bg-sky-300'
-								href={`/dashboard/write?slug=${post.slug}`}
-							>
-								수정
-							</Link>
-						</div>
-					)}
+					<p className='mt-2 text-sm text-slate-400'>
+						{dayjs(post.created_at).format('YYYY년 MM월 DD일')}
+					</p>
 				</div>
-
-				<div className='mt-2 flex justify-between text-sm text-slate-400'>
-					<p>{post.description}</p>
-					<p>{post.created_at}</p>
-				</div>
+				{isDashboard && (
+					<div className='flex items-center gap-2'>
+						<button
+							className='rounded-md border-red-500 bg-red-500 px-2 py-1 text-sm font-medium text-white hover:bg-red-300'
+							onClick={(e) => {
+								e.preventDefault();
+								openModal();
+							}}
+						>
+							삭제
+						</button>
+						<Link
+							className='rounded-md border-sky-500 bg-sky-500 px-2 py-1 text-sm font-medium text-white hover:bg-sky-300'
+							href={`/dashboard/write?slug=${post.slug}`}
+						>
+							수정
+						</Link>
+					</div>
+				)}
 			</article>
 
 			{isDashboard && (

--- a/src/app/components/Search.tsx
+++ b/src/app/components/Search.tsx
@@ -35,7 +35,7 @@ export default function Search({ placeholder }: { placeholder: string }) {
 				defaultValue={searchParams.get('query')?.toString()}
 			/>
 			<SearchIcon
-				className='absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 peer-focus:text-gray-900'
+				className='absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 dark:peer-focus:text-gray-300'
 				width={24}
 				height={24}
 			/>

--- a/src/app/components/skeletons/PostListSkeleton.tsx
+++ b/src/app/components/skeletons/PostListSkeleton.tsx
@@ -1,0 +1,39 @@
+const PostListItemSkeleton = ({ isDashboard = false }) => (
+	<div className='mb-8 flex animate-pulse'>
+		<div className='flex-1'>
+			<div className='mb-2 h-6 w-3/4 rounded bg-gray-200'></div>
+			<div className='h-4 w-1/4 rounded bg-gray-200'></div>
+		</div>
+		{isDashboard && (
+			<div className='flex items-center gap-2'>
+				<div className='h-8 w-12 rounded bg-gray-200'></div>
+				<div className='h-8 w-12 rounded bg-gray-200'></div>
+			</div>
+		)}
+	</div>
+);
+
+const PostListSkeleton = ({ itemsCount = 10, isDashboard = false }) => {
+	return (
+		<div className='flex h-auto w-full flex-1 flex-col items-center pb-4'>
+			<ul className='mb-2 w-full list-none'>
+				{Array.from({ length: itemsCount }).map((_, index) => (
+					<li key={index} className='my-1'>
+						<PostListItemSkeleton isDashboard={isDashboard} />
+					</li>
+				))}
+			</ul>
+			<div className='flex flex-1 animate-pulse items-end justify-center gap-2'>
+				<div className='h-8 w-8 rounded bg-gray-200'></div>
+				<div className='flex gap-1'>
+					{Array.from({ length: 5 }).map((_, index) => (
+						<div key={index} className='h-8 w-8 rounded bg-gray-200'></div>
+					))}
+				</div>
+				<div className='h-8 w-8 rounded bg-gray-200'></div>
+			</div>
+		</div>
+	);
+};
+
+export { PostListSkeleton, PostListItemSkeleton };

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -11,8 +11,7 @@ export const createPostData = async (
 ) => {
 	const baseSlug = customSlugify(title);
 	const slug = `${baseSlug}-${uuidv4()}`;
-
-	const created_at = dayjs().locale('ko').format('YYYY-MM-DD');
+	const created_at = dayjs().format('YYYY-MM-DD');
 
 	const postData: Post = {
 		slug,


### PR DESCRIPTION
> 관련 이슈: #33 

## 전달 사항
이번 작업에서는 게시글 목록 컴포넌트의 레이아웃을 수정하고, 스켈레톤 UI를 구현했습니다.

## 주요 변경 사항
- 게시글 목록 컴포넌트 레이아웃 수정
- 스켈레톤 UI 구현

## 추후 작업
로그인 페이지 유효성 검사 및 토스트 알림 추가
