### PR TITLE
Refactor: 블로그 포스트 페이지에 ISR 기법 적용 #44

### DIFF
--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -2,8 +2,28 @@ import PostHeader from '../../../components/PostHeader';
 import PostBody from '../../../components/PostBody';
 import Giscus from '../../../components/Giscus';
 import dayjs from 'dayjs';
-import { getPostFromSlug } from '@/src/utils/supabase/serverActions';
+import {
+	getPostFromSlug,
+	getAllPosts,
+} from '@/src/utils/supabase/serverActions';
 import { Metadata } from 'next';
+
+export const revalidate = 60;
+
+export const dynamicParams = true;
+
+export async function generateStaticParams() {
+	const posts = await getAllPosts();
+
+	if (!posts) {
+		console.error('포스트를 가져오는데 실패했습니다');
+		return [];
+	}
+
+	return posts.map((post) => ({
+		slug: post.slug,
+	}));
+}
 
 export async function generateMetadata({
 	params,

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -2,10 +2,8 @@ import PostHeader from '../../../components/PostHeader';
 import PostBody from '../../../components/PostBody';
 import Giscus from '../../../components/Giscus';
 import dayjs from 'dayjs';
-import {
-	getPostFromSlug,
-	getAllPosts,
-} from '@/src/utils/supabase/serverActions';
+import { getPostFromSlug } from '@/src/utils/supabase/serverActions';
+import { getAllPosts } from '@/src/utils/supabase/clientActions';
 import { Metadata } from 'next';
 
 export const revalidate = 60;

--- a/src/utils/supabase/clientActions.ts
+++ b/src/utils/supabase/clientActions.ts
@@ -4,6 +4,17 @@ import { Post } from '@/src/interfaces/post';
 import { customSlugify } from '@/src/lib/api';
 import { v4 as uuidv4 } from 'uuid';
 
+export const getAllPosts = async () => {
+	const { data, error } = await supabaseClient.from('posts').select('*');
+
+	if (error) {
+		console.error('오류가 발생했습니다:', error);
+		return null;
+	}
+
+	return data;
+};
+
 export const createPostData = async (
 	title: string,
 	description: string,

--- a/src/utils/supabase/serverActions.ts
+++ b/src/utils/supabase/serverActions.ts
@@ -90,18 +90,6 @@ export async function fetchLatestPost() {
 	return data;
 }
 
-export const getAllPosts = async () => {
-	const supabase = createClient();
-	const { data, error } = await supabase.from('posts').select('*');
-
-	if (error) {
-		console.error('오류가 발생했습니다:', error);
-		return null;
-	}
-
-	return data;
-};
-
 export const getPostSlugs = async () => {
 	const supabase = createClient();
 	const { data, error } = await supabase.from('posts').select('slug');

--- a/src/utils/supabase/serverActions.ts
+++ b/src/utils/supabase/serverActions.ts
@@ -90,6 +90,18 @@ export async function fetchLatestPost() {
 	return data;
 }
 
+export const getAllPosts = async () => {
+	const supabase = createClient();
+	const { data, error } = await supabase.from('posts').select('*');
+
+	if (error) {
+		console.error('오류가 발생했습니다:', error);
+		return null;
+	}
+
+	return data;
+};
+
 export const getPostSlugs = async () => {
 	const supabase = createClient();
 	const { data, error } = await supabase.from('posts').select('slug');


### PR DESCRIPTION
> 관련 이슈: #44 

## 전달 사항
본 PR에서는 블로그 포스트 페이지 ISR 기법 적용에 대해서 다루고 있습니다.

## 주요 변경 사항
블로그의 포스트는 실시간 변동사항이 거의 없다는 점을 감안하여, SSR 기반의 콘텐츠 제공 방식을 점진적 증분 재생성(ISR)으로 변경했습니다.
```ts
export const getAllPosts = async () => {
	const { data, error } = await supabaseClient.from('posts').select('*');
        
        // 오류 처리 로직은 추가 이슈로 한꺼번에 수정 예정
	if (error) {
		console.error('오류가 발생했습니다:', error);
		return null;
	}
        
	return data;
};
```
먼저 `getAllPosts`라는 메서드를 만들어 블로그 콘텐츠 페이지 컴포넌트에서 사용할 수 있도록 했습니다.

```tsx
// page.tsx
export const revalidate = 60;

export const dynamicParams = true;

export async function generateStaticParams() {
	const posts = await getAllPosts();

	if (!posts) {
		console.error('포스트를 가져오는데 실패했습니다');
		return [];
	}

	return posts.map((post) => ({
		slug: post.slug,
	}));
}
```

또한 revalidate를 활용해 점진적 증분 재생성의 갱신 주기를 고려했습니다.

```text
[17:39:40.174] Error: `cookies` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
[17:39:40.175]     at getExpectedRequestStore (/vercel/path0/node_modules/next/dist/client/components/request-async-storage.external.js:28:11)
[17:39:40.175]     at u (/vercel/path0/.next/server/chunks/362.js:1:31956)
[17:39:40.176]     at n (/vercel/path0/.next/server/app/(dashboard)/dashboard/page.js:26:7876)
[17:39:40.176]     at b (/vercel/path0/.next/server/app/(dashboard)/dashboard/posts/[slug]/page.js:11:6712)
[17:39:40.178]     at Object.p [as generateStaticParams] (/vercel/path0/.next/server/app/(blog)/blog/[slug]/page.js:6:11475)
[17:39:40.179]     at buildParams (/vercel/path0/node_modules/next/dist/build/utils.js:1026:58)
[17:39:40.179]     at buildParams (/vercel/path0/node_modules/next/dist/build/utils.js:1020:28)
[17:39:40.180]     at /vercel/path0/node_modules/next/dist/build/utils.js:1043:39
[17:39:40.180]     at AsyncLocalStorage.run (node:async_hooks:346:14)
[17:39:40.180]     at Object.wrap (/vercel/path0/node_modules/next/dist/server/async-storage/static-generation-async-storage-wrapper.js:49:24)
[17:39:40.182] 
[17:39:40.182] > Build error occurred
[17:39:40.183] Error: Failed to collect page data for /blog/[slug]
[17:39:40.183]     at /vercel/path0/node_modules/next/dist/build/utils.js:1268:15
[17:39:40.183]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
[17:39:40.183]   type: 'Error'
[17:39:40.183] }
[17:39:40.211] Error: Command "npm run build" exited with 1
[17:39:40.596] 
```

빌드 도중 위와 같은 오류가 발생하기도 했는데, 이는 초기 쿠키를 사용하는 Supabase 서버 클라이언트를 기반으로 `getAllPosts` 메서드를 선언했기 때문이었습니다. 따라서 해당 메서드를 클라이언트 액션에서 선언하는 것으로 변경해 오류를 해결했습니다.

## 추후 작업
블로그 포스트 페이지의 가독성 향상을 위한 CSS 수정
